### PR TITLE
helper类测试程序

### DIFF
--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -376,6 +376,15 @@ inline const char* device_error_string( rocblas_status error )
                                           blas::device_error_string(e), \
                                           __func__ ); \
             } while(0)
+
+        #define HelperSafeCall( error ) \
+            do{ \
+                auto e = error; \
+                blas::internal::helper_safe_call( blas::is_device_error(e), \
+                                                blas::device_error_string(e), \
+                                                __FILE__, __LINE__, #error); \
+            }while (0)
+
     #endif
 
 #endif

--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -11,6 +11,11 @@
 #include <cstdarg>
 #include <limits>
 #include <vector>
+#include <iostream>
+#include <fstream>
+#include <cstring>
+#include <ctime>
+
 
 #include <assert.h>
 
@@ -502,11 +507,42 @@ inline void throw_if( bool cond, const char* condstr, const char* func )
 
 inline void helper_safe_call( bool cond, const char* condstr, const char *filename, const int fileline,  const char *func)
 {
+    size_t id = 0;
+    for(size_t i=0; i<strlen(func); i++){
+        if(func[i]=='('){id=i; break;}
+    }
     if(cond){
+        printf("API: %s is failed\n", ((std::string(func)).substr(0,id)).c_str());
+        time_t now = time(nullptr);    
+        char* curr_time = ctime(&now);
+        curr_time[strlen(curr_time)-1]='\0';
+        std::ofstream file("failed_result.csv", std::ios::app);
+        if (!file.is_open()) {
+            printf("!!!! Unable to open file\n");
+            return;
+        }
+        // Write your data to the file
+        file << curr_time << "," << std::string(func).substr(0, id) << "," << "failed" << "," << condstr << std::endl;
+        file.close();
+
         throw Error((std::string(condstr) + std::string("   filename is:  ") 
         + std::string(filename) 
         + std::string("  Error line is: ")
         + std::to_string(fileline)).c_str(), func);
+    }
+    else{
+        printf("API: %s is success\n", ((std::string(func)).substr(0,id)).c_str());
+        time_t now = time(nullptr);    
+        char* curr_time = ctime(&now);
+        curr_time[strlen(curr_time)-1]='\0';
+        std::ofstream file("succeed_result.csv", std::ios::app);
+        if (!file.is_open()) {
+            printf("!!!! Unable to open file\n");
+            return;
+        }
+        // Write your data to the file
+        file << curr_time << "," << std::string(func).substr(0, id) << "," << "success" << std::endl;
+        file.close();
     }
 }
 

--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -500,6 +500,16 @@ inline void throw_if( bool cond, const char* condstr, const char* func )
     }
 }
 
+inline void helper_safe_call( bool cond, const char* condstr, const char *filename, const int fileline,  const char *func)
+{
+    if(cond){
+        throw Error((std::string(condstr) + std::string("   filename is:  ") 
+        + std::string(filename) 
+        + std::string("  Error line is: ")
+        + std::to_string(fileline)).c_str(), func);
+    }
+}
+
 #if defined(_MSC_VER)
     #define BLASPP_ATTR_FORMAT(I, F)
 #else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,6 +128,25 @@ add_executable(
     test_trsm_device.cc
 )
 
+file(GLOB HELPHH ${PROJECT_SOURCE_DIR}/test/helper* lapack_wrappers.cc)
+
+add_executable(helper ${HELPHH}) 
+
+set_target_properties( helper PROPERTIES CXX_EXTENSIONS false )
+target_link_libraries(helper 
+testsweeper 
+blaspp     
+${blaspp_cblas_libraries}
+${lapack_libraries_}
+)
+
+target_include_directories(
+    helper
+    PRIVATE
+        "${blaspp_cblas_include}"
+)
+
+
 # C++11 is inherited from blaspp, but disabling extensions is not.
 set_target_properties( ${tester} PROPERTIES CXX_EXTENSIONS false )
 

--- a/test/helper.cc
+++ b/test/helper.cc
@@ -56,7 +56,7 @@ int main( int argc, char** argv )
         || strcmp( argv[argc-1], "-h" ) == 0
         || strcmp( argv[argc-1], "--help" ) == 0)
     {
-        printf(" please test1 or testxxx\n");
+        printf(" please test1 or test2\n");
         return 0;
     }
     const char* routine = argv[ argc-1 ];

--- a/test/helper.cc
+++ b/test/helper.cc
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "helper.hh"
+
+using testsweeper::ParamType;
+using testsweeper::DataType;
+using testsweeper::char2datatype;
+using testsweeper::datatype2char;
+using testsweeper::datatype2str;
+using testsweeper::ansi_bold;
+using testsweeper::ansi_red;
+using testsweeper::ansi_normal;
+
+
+typedef void (*test_help_func_ptr)();
+
+typedef struct {
+    const char* name;
+    test_help_func_ptr func;
+    int section;
+} routines_help_t;
+
+
+test_help_func_ptr find_help_tester(
+    const char *name,
+    std::vector< routines_help_t >& routines )
+{
+    for (size_t i = 0; i < routines.size(); ++i) {
+        if (strcmp( name, routines[i].name ) == 0) {
+            return routines[i].func;
+        }
+    }
+    return nullptr;
+}
+
+enum SectionHelp {
+    newline = 0,  // zero flag forces newline
+    test1,
+    test2,
+    test3,
+    aux,
+    num_sections,  // last
+};
+
+std::vector< routines_help_t > routines = {
+    {"test1", helper_test1, SectionHelp::test1},
+    {"test2", helper_test2, SectionHelp::test1},
+    { "", nullptr, SectionHelp::newline},
+};
+
+int main( int argc, char** argv )
+{
+    if (argc < 2
+        || strcmp( argv[argc-1], "-h" ) == 0
+        || strcmp( argv[argc-1], "--help" ) == 0)
+    {
+        printf(" please test1 or testxxx\n");
+        return 0;
+    }
+    const char* routine = argv[ argc-1 ];
+    test_help_func_ptr test_help_routine = find_help_tester( routine, routines );
+    if(test_help_routine ==nullptr){
+        printf("input routine name error!\n");
+        printf("please input test1 or testxxx\n");
+        return 0;
+    }
+    try{
+        test_help_routine();
+    }
+    catch (const std::exception& ex) {
+        fprintf( stderr, "%s%sError: %s%s\n",
+                  ansi_bold, ansi_red, ex.what(), ansi_normal );
+    }
+    
+
+  return 0;
+}

--- a/test/helper.hh
+++ b/test/helper.hh
@@ -1,0 +1,15 @@
+#ifndef HELPER_HH
+#define HELPER_HH
+
+
+#include "testsweeper.hh"
+#include "blas.hh"
+
+
+using llong = long long;
+
+
+void helper_test1();
+void helper_test2();
+
+#endif

--- a/test/helper_test1.cc
+++ b/test/helper_test1.cc
@@ -19,10 +19,14 @@ void helper_test1()
     printf("The helper API for this routine test is as follows:  \n \
             cublasCreate  cublasDestroy \n \
             cublasSetStream cublasGetStream\n \
-            cublasSetPointerMode(Device) cublasSetPointerMode(Host) \n \
+            cublasSetPointerMode(Device) \n \
+            cublasSetPointerMode(Host) \n \
             cublasGetPointerMode \n \
             cublasSetVector  cublasGetVector\n \
-            cublasSetVectorAsync cublasGetVectorAsync\n");
+            cublasSetVectorAsync cublasGetVectorAsync\n \
+            cublasLoggerConfigure \n \
+            cublasSetLoggerCallback \n \
+            cublasGetLoggerCallback\n ");
     int64_t device = 0;
     if (blas::get_device_count() == 0) {
         printf("skipping: no GPU devices or no GPU support\n");
@@ -45,8 +49,10 @@ void helper_test1()
     HelperSafeCall(cublasGetPointerMode(handle, &mode));
 
     //set log
-    HelperSafeCall(cublasLoggerConfigure(1, 1, 1, "helper.log"));
-    HelperSafeCall(cublasSetLoggerCallback(print));
+    cublasLogCallback calfunc;
+    HelperSafeCall(cublasLoggerConfigure(1, 0, 0, "helper.log"));
+    HelperSafeCall(cublasSetLoggerCallback(NULL));
+    HelperSafeCall(cublasGetLoggerCallback(&calfunc));
 
 
     //test cublasGetStream()

--- a/test/helper_test1.cc
+++ b/test/helper_test1.cc
@@ -5,13 +5,13 @@
 #include "print_matrix.hh"
 #include  "../src/device_internal.hh"
 
-typedef void (*test_log_func_ptr)(void* userData, cublasStatus_t status, const char* msg);
+// typedef void (*test_log_func_ptr)(void* userData, cublasStatus_t status, const char* msg);
 
 
-void print(void* userData, cublasStatus_t status, const char* msg) {
-    // 在这里处理日志信息
-    printf("logging: %s\n", msg);
-}
+// void print(void* userData, cublasStatus_t status, const char* msg) {
+//     // 在这里处理日志信息
+//     printf("logging: %s\n", msg);
+// }
 
 
 void helper_test1()

--- a/test/helper_test1.cc
+++ b/test/helper_test1.cc
@@ -1,0 +1,168 @@
+#include "helper.hh"
+#include "lapack_wrappers.hh"
+#include "cblas_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include  "../src/device_internal.hh"
+
+typedef void (*test_log_func_ptr)(void* userData, cublasStatus_t status, const char* msg);
+
+
+void print(void* userData, cublasStatus_t status, const char* msg) {
+    // 在这里处理日志信息
+    printf("logging: %s\n", msg);
+}
+
+
+void helper_test1()
+{
+    printf("The helper API for this routine test is as follows:  \n \
+            cublasCreate  cublasDestroy \n \
+            cublasSetStream cublasGetStream\n \
+            cublasSetPointerMode(Device) cublasSetPointerMode(Host) \n \
+            cublasGetPointerMode \n \
+            cublasSetVector  cublasGetVector\n \
+            cublasSetVectorAsync cublasGetVectorAsync\n");
+    int64_t device = 0;
+    if (blas::get_device_count() == 0) {
+        printf("skipping: no GPU devices or no GPU support\n");
+        return;
+    }
+    int64_t n = 100;
+    int64_t incx = 1;
+    //test cublasCreate(), cublasDestroy(), cublasSetStream()
+    cudaStream_t stream = blas::stream_create(device);
+    cublasHandle_t handle;
+    HelperSafeCall(cublasCreate( &handle ));
+    HelperSafeCall( cublasSetStream( handle, stream ) );
+
+
+    // Set the pointer mode  test cublasSetPointerMode
+    HelperSafeCall(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST) );
+
+    // Get the pointer mode, test cublasGetPointerMode
+    cublasPointerMode_t mode;
+    HelperSafeCall(cublasGetPointerMode(handle, &mode));
+
+    //set log
+    HelperSafeCall(cublasLoggerConfigure(1, 1, 1, "helper.log"));
+    HelperSafeCall(cublasSetLoggerCallback(print));
+
+
+    //test cublasGetStream()
+    cudaStream_t test_stream;
+    HelperSafeCall(cublasGetStream( handle, &test_stream));
+
+    //set a queue
+    //blas::Queue queue(device, handle);
+
+    size_t size_x = (n - 1) * std::abs(incx) + 1;
+
+
+
+    float *x, *xcopy, *xasync;
+    x = new float[ size_x ];
+    xcopy = new float[ size_x ];
+    xasync = new float[ size_x ];
+
+    //HelperSafeCall(cudaMallocManaged((float**)&x, size_x*sizeof(float)) );
+    //HelperSafeCall(cudaMallocManaged((float**)&xcopy, size_x*sizeof(float)) );
+    //HelperSafeCall(cudaMallocManaged((float**)&xasync, size_x*sizeof(float)) );
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    //init data
+    lapack_larnv( idist, iseed, size_x, x );
+
+    float *dx, *dxp, *dasync, *dm;
+
+
+    HelperSafeCall(cudaMalloc((float**)&dx, size_x*sizeof(float)) );
+    HelperSafeCall(cudaMalloc((float**)&dxp, size_x*sizeof(float)) );
+    HelperSafeCall(cudaMalloc((float**)&dasync, size_x*sizeof(float)) );
+
+
+    
+    HelperSafeCall(cudaMemcpy(dx, x, size_x*sizeof(float),cudaMemcpyHostToDevice));
+
+    HelperSafeCall(cublasSetVector(size_x, sizeof(float), x, incx, dxp, incx));
+    //test cublasGetVector
+    HelperSafeCall(cublasGetVector(size_x, sizeof(float), dxp, incx, xcopy, incx));
+    for(int i=0; i<n; i++){
+        if(x[i*incx]!=xcopy[i*incx]){
+            printf("cublasSetVector or cublasGetVector error\n");
+            return;
+        }
+    }
+
+
+    //test cublasSetVectorAsync
+    HelperSafeCall(cublasSetVectorAsync(size_x, sizeof(float), x, incx, dasync, incx, test_stream));
+    //queue.sync();
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+    //test cublasGetVectorAsync
+    HelperSafeCall(cublasGetVectorAsync(size_x, sizeof(float), dasync, incx, xasync, incx, test_stream));
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+    //queue.sync();
+    for(int i=0; i<n; i++){
+        if(x[i*incx]!=xasync[i*incx]){
+            printf("cublasSetVectorAsync or cublasGetVectorAsync error\n");
+            return;
+        }
+    }
+
+    float result_host;
+    float result_device;
+    //run cublas api
+    // blas::asum( n, dx, incx, &result_device, queue);
+    // queue.sync();
+    HelperSafeCall(
+        cublasSasum(handle, n, dx, incx, &result_device)
+    );
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+
+    //run cblas api
+    result_host = cblas_asum(n, x, incx);
+    
+    float error = std::abs( (result_host - result_device) / (n * result_host) );
+    float u = 0.5 * std::numeric_limits< float >::epsilon();
+
+    printf("Host pointer: cblas result is : %f  cublas result is: %f error is: %f  ",result_host,result_device, error);
+    if(error < u) {printf("Result pass\n");}
+    else {printf("Result is error\n");}
+    
+    //--------------------------------------DEVICE--------------
+    float *result_h;
+    HelperSafeCall(cudaMalloc((float**)&result_h, sizeof(float)) );
+    // Set the pointer mode  test cublasSetPointerMode
+    HelperSafeCall(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE) );
+    HelperSafeCall(cublasGetStream( handle, &test_stream));
+    HelperSafeCall(
+        cublasSasum(handle, n, dx, incx, result_h)
+    );
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+
+    HelperSafeCall(cudaMemcpy(&result_device, result_h, sizeof(float),cudaMemcpyDeviceToHost));
+    
+    float error2 = std::abs( (result_host - result_device) / (n * result_host) );
+    //float u = 0.5 * std::numeric_limits< float >::epsilon();
+
+    printf("Device pointer: cblas result is : %f  cublas result is: %f error is: %f ",result_host,result_device, error2);
+    if(error < u) {printf("Result pass\n All helper api tests passed \n");}
+    else {printf("Result is error\n");}
+    //---------------------------------------END-----------------
+    delete [] x;
+    delete [] xcopy;
+    delete [] xasync;
+
+    cudaFree(dasync);
+    cudaFree(dx);
+    cudaFree(dxp);
+    cudaFree(result_h);
+    // blas::device_free(dasync, queue);
+    // blas::device_free(dx, queue);
+    //test cublasDestroy
+    HelperSafeCall(cublasDestroy(handle));
+    HelperSafeCall(cudaStreamDestroy(test_stream));
+    return;
+}
+

--- a/test/helper_test2.cc
+++ b/test/helper_test2.cc
@@ -1,0 +1,168 @@
+#include "helper.hh"
+#include "cblas_wrappers.hh"
+#include "lapack_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include "check_gemm.hh"
+#include  "../src/device_internal.hh"
+
+void helper_test2()
+{
+    using blas::Op;
+    using blas::Layout;
+    printf("The helper API for this routine test is as follows:  \n \
+            cublasCreate  cublasDestroy \n \
+            cublasSetStream cublasGetStream\n \
+            cublasSetMatrix  cublasGetMatrix\n \
+            cublasSetMatrixAsync cublasGetMatrixAsync\n");
+    int64_t device = 0;
+    if (blas::get_device_count() == 0) {
+        printf("skipping: no GPU devices or no GPU support\n");
+        return;
+    }
+    int64_t m = 4;
+    int64_t n = 4;
+    int64_t k = 4;
+    cublasOperation_t transA = cublasOperation_t::CUBLAS_OP_N;
+    cublasOperation_t transB = cublasOperation_t::CUBLAS_OP_T;
+    const float alpha = 3.14;
+    const float beta = 2.71;
+    //test cublasCreate(), cublasDestroy(), cublasSetStream()
+    cudaStream_t stream = blas::stream_create(device);
+    cublasHandle_t handle;
+    HelperSafeCall(cublasCreate( &handle ));
+    HelperSafeCall( cublasSetStream( handle, stream ) );
+
+
+    // Set the pointer mode  test cublasSetPointerMode
+    // HelperSafeCall(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST) );
+
+    // Get the pointer mode, test cublasGetPointerMode
+    // cublasPointerMode_t mode;
+    // HelperSafeCall(cublasGetPointerMode(handle, &mode));
+
+    //test cublasGetStream()
+    cudaStream_t test_stream;
+    HelperSafeCall(cublasGetStream( handle, &test_stream));
+
+    size_t size_A = m * k;
+    size_t size_B = n * k;
+    size_t size_C = m * n;
+
+    int64_t lda = m;
+    int64_t ldb = n;
+    int64_t ldc = m;
+    //host
+    float *A  = new float[size_A];
+    float *Ap = new float[size_A];
+    float *B  = new float[size_B];
+    float *C  = new float[size_C];
+    float *Cref = new float[size_C];
+
+    //device 
+    float *dA, *dB, *dC;
+    float *dAy;
+    HelperSafeCall(cudaMalloc((float**)&dA, size_A*sizeof(float)) );
+    HelperSafeCall(cudaMalloc((float**)&dB, size_B*sizeof(float)) );
+    HelperSafeCall(cudaMalloc((float**)&dC, size_C*sizeof(float)) );
+    HelperSafeCall(cudaMalloc((float**)&dAy, size_A*sizeof(float)) );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    //init data
+    lapack_larnv( idist, iseed, size_A, A );
+    lapack_larnv( idist, iseed, size_B, B );
+    lapack_larnv( idist, iseed, size_C, C );
+    lapack_lacpy( "g", m, n, C, ldc, Cref, ldc );
+
+    // norms for error check
+    float work[1];
+    float Anorm = lapack_lange( "f", m, k, A, lda, work );
+    float Bnorm = lapack_lange( "f", n, k, B, ldb, work );
+    float Cnorm = lapack_lange( "f", m, n, C, ldc, work );
+    
+    // HelperSafeCall(cudaMemcpy(dA, A, size_A*sizeof(float),cudaMemcpyHostToDevice));
+    // HelperSafeCall(cudaMemcpy(dB, B, size_B*sizeof(float),cudaMemcpyHostToDevice));
+
+    HelperSafeCall(cublasSetMatrix(m, k, sizeof(float), A, lda, dA, lda));
+    HelperSafeCall(cublasSetMatrix(n, k, sizeof(float), B, ldb, dB, ldb));
+    HelperSafeCall(cublasSetMatrix(m, n, sizeof(float), C, ldc, dC, ldc));
+    //test cublasGetVector
+    HelperSafeCall(cublasGetMatrix(m, k, sizeof(float), dA, lda, Ap, lda));
+    for(int i=0; i<m; i++){
+        for(int j=0; j<k; j++){
+            if(A[j*m + k]!=Ap[j*m + k]){
+                printf("cublasSetMatrix or cublasGetMatrix error\n");
+                return;
+            }
+        }
+    }
+    memset(Ap, 0, m*k*sizeof(float));
+
+    //test cublasSetMatrixAsync
+    HelperSafeCall(cublasSetMatrixAsync(m, k, sizeof(float), A, lda, dAy, lda, test_stream));
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+
+    //test cublasGetMatrixAsync
+    HelperSafeCall(cublasGetMatrixAsync(m, k, sizeof(float), dAy, lda, Ap, lda, test_stream));
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+    for(int i=0; i<m; i++){
+        for(int j=0; j<k; j++){
+            if(A[j*m + k]!=Ap[j*m + k]){
+                printf("cublasSetMatrixAsync or cublasGetMatrixAsync error\n");
+                return;
+            }
+        }
+    }
+    //run cublas api
+    HelperSafeCall(
+        cublasSgemm(handle, transA, transB, m, n, k, &alpha, dA, 
+                    lda, dB, ldb, &beta, dC, ldc);
+    );
+    HelperSafeCall(cudaStreamSynchronize(test_stream));
+    HelperSafeCall(cudaMemcpy(C, dC, m*n*sizeof(float), cudaMemcpyDeviceToHost));
+
+    //run cblas api
+    cblas_gemm(CblasColMajor, CblasNoTrans, CblasTrans, m, n, k, 
+               alpha, A, lda, B, ldb, beta, Cref, ldc);
+    // printf("cblas: \n");
+    // for(int i=0; i<m; i++){
+    //     for(int j=0; j<n; j++){
+    //         printf("%.3f ",Cref[j*m+i]);
+    //     }
+    //     printf("\n");
+    // }
+    // printf("cublas: \n");
+    // for(int i=0; i<m; i++){
+    //     for(int j=0; j<n; j++){
+    //         printf("%.3f ",C[j*m+i]);
+    //     }
+    //     printf("\n");
+    // }
+    float error=0;
+    bool okay;
+    check_gemm( m, n, k, alpha, beta, Anorm, Bnorm, Cnorm,
+                   Cref, ldc, C, ldc, false, &error, &okay );
+
+    printf("Error is: %f  ", error);
+    if(okay) {printf("Result pass\n");}
+    else {printf("Result is error\n");}
+    
+    delete [] A;
+    delete [] B;
+    delete [] C;
+    delete [] Cref;
+    delete [] Ap;
+
+    cudaFree(dA);
+    cudaFree(dB);
+    cudaFree(dC);
+    cudaFree(dAy);
+    // blas::device_free(dasync, queue);
+    // blas::device_free(dx, queue);
+    //test cublasDestroy
+    HelperSafeCall(cublasDestroy(handle));
+    HelperSafeCall(cudaStreamDestroy(test_stream));
+    return;
+}
+


### PR DESCRIPTION
##helper类方法测试
helper类方法测试独立于tester可执行程序，编译完成后会生成helper可执行程序
### 测试结果
./helper test1
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/b6b4cb94-f07f-4ee4-8ca2-2c2a3d6161fa)

./helper test2
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/133ef4bf-68fc-4472-bd5e-ffb46eb813b7)

假设当API测试出现问题时，显示如下：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/d759e6af-90df-4751-8ac6-7858e61b538a)


### helper测试程序日志
测试程序不仅会将结果打印在终端，还会将结果存储在csv文件中，分别为succeed_result.csv和failed_result.csv
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/0be681ec-2c08-4fd0-a687-2d76435d1d94)

文件内容以追加模式添加：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/b2198d5d-45a2-4d81-b458-383aa1f3fcca)

![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/cddc206d-a74d-40e6-8e9f-88de5258f0e9)

cublasLoggerConfigure API配置的日志会存储在helper.log文件中，如下：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/2f1e1c05-2e60-47bb-ab7f-4d6a4e53fc6d)







