### PR TITLE
增加gemm日志和helper类测试方法调整

### DIFF
--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -377,7 +377,10 @@ inline const char* device_error_string( rocblas_status error )
                                           blas::device_error_string(e), \
                                           __func__ ); \
             } while(0)
-
+        
+        #define Blas_Match_Call( cond , error ) \
+                blas::internal::blas_match_call(cond, error,  __FILE__, __LINE__, #cond);
+        
         #define HelperSafeCall( error ) \
             do{ \
                 auto e = error; \
@@ -386,6 +389,10 @@ inline const char* device_error_string( rocblas_status error )
                                                 __FILE__, __LINE__, #error); \
             }while (0)
 
+        #define HelperTestCall( funcname, cond, error ) \
+                blas::internal::helper_safe_call( !cond, \
+                                                blas::device_error_string(error), \
+                                                __FILE__, __LINE__, funcname, 0);
     #endif
 
 #endif

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -389,10 +389,10 @@ inline const char* device_error_string( rocblas_status error )
                                                 __FILE__, __LINE__, #error); \
             }while (0)
 
-        #define HelperTestCall( funcname, cond, error ) \
+        #define HelperTestCall( funcname, cond, error, except_error) \
                 blas::internal::helper_safe_call( !cond, \
                                                 blas::device_error_string(error), \
-                                                __FILE__, __LINE__, funcname, 0);
+                                                __FILE__, __LINE__, funcname, except_error, 0);
     #endif
 
 #endif

--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -505,43 +505,96 @@ inline void throw_if( bool cond, const char* condstr, const char* func )
     }
 }
 
-inline void helper_safe_call( bool cond, const char* condstr, const char *filename, const int fileline,  const char *func)
+inline void blas_match_call( bool cond, const char* condstr, const char *filename, const int fileline,  const char *func)
 {
     size_t id = 0;
     for(size_t i=0; i<strlen(func); i++){
         if(func[i]=='('){id=i; break;}
     }
-    if(cond){
-        printf("API: %s is failed\n", ((std::string(func)).substr(0,id)).c_str());
+    if(!cond){
+        //printf("API: %s is failed\n", ((std::string(func)).substr(0,id)).c_str());
         time_t now = time(nullptr);    
         char* curr_time = ctime(&now);
         curr_time[strlen(curr_time)-1]='\0';
-        std::ofstream file("failed_result.csv", std::ios::app);
+        std::ofstream file("blas_routine_failed_result.csv", std::ios::app);
         if (!file.is_open()) {
             printf("!!!! Unable to open file\n");
             return;
         }
         // Write your data to the file
-        file << curr_time << "," << std::string(func).substr(0, id) << "," << "failed" << "," << condstr << std::endl;
+        file << curr_time << "," << std::string(func).substr(0, id) << "," \
+        << "failed" << "," << condstr << "," << std::string(filename) <<"," \
+        << std::to_string(fileline) <<std::endl;
         file.close();
 
-        throw Error((std::string(condstr) + std::string("   filename is:  ") 
-        + std::string(filename) 
-        + std::string("  Error line is: ")
-        + std::to_string(fileline)).c_str(), func);
+        // throw Error((std::string(condstr) + std::string("   filename is:  ") 
+        // + std::string(filename) 
+        // + std::string("  Error line is: ")
+        // + std::to_string(fileline)).c_str(), func);
+    }
+    else{
+        //printf("API: %s is success\n", ((std::string(func)).substr(0,id)).c_str());
+        time_t now = time(nullptr);    
+        char* curr_time = ctime(&now);
+        curr_time[strlen(curr_time)-1]='\0';
+        std::ofstream file("blas_routine_succeed_result.csv", std::ios::app);
+        if (!file.is_open()) {
+            printf("!!!! Unable to open file\n");
+            return;
+        }
+        // Write your data to the file
+        file << curr_time << "," << std::string(func).substr(0, id) << "," \
+        << "succeed" << "," << condstr << "," << std::string(filename) <<"," \
+        << std::to_string(fileline) <<std::endl;
+        file.close();
+    }
+}
+
+inline void helper_safe_call( bool cond, const char* condstr, const char *filename, const int fileline,  const char *func, const int flag = 1)
+{
+    size_t id = 0;
+    for(size_t i=0; i<strlen(func); i++){
+        if(func[i]=='('){id=i; break;}
+    }
+    if(id==0) id = strlen(func);
+    if(cond){
+        printf("API: %s is failed\n", ((std::string(func)).substr(0,id)).c_str());
+        time_t now = time(nullptr);    
+        char* curr_time = ctime(&now);
+        curr_time[strlen(curr_time)-1]='\0';
+        std::ofstream file("helper_failed_result.csv", std::ios::app);
+        if (!file.is_open()) {
+            printf("!!!! Unable to open file\n");
+            return;
+        }
+        // Write your data to the file
+        //file << curr_time << "," << std::string(func).substr(0, id) << "," << "failed" << "," << condstr << std::endl;
+        file << curr_time << "," << std::string(func).substr(0, id) << "," \
+        << "failed" << "," << condstr << "," << std::string(filename) <<"," \
+        << std::to_string(fileline) <<std::endl;
+        file.close();
+        if(flag){
+            throw Error((std::string(condstr) + std::string("   filename is:  ") 
+            + std::string(filename) 
+            + std::string("  Error line is: ")
+            + std::to_string(fileline)).c_str(), func);
+        }
     }
     else{
         printf("API: %s is success\n", ((std::string(func)).substr(0,id)).c_str());
         time_t now = time(nullptr);    
         char* curr_time = ctime(&now);
         curr_time[strlen(curr_time)-1]='\0';
-        std::ofstream file("succeed_result.csv", std::ios::app);
+        std::ofstream file("helper_succeed_result.csv", std::ios::app);
         if (!file.is_open()) {
             printf("!!!! Unable to open file\n");
             return;
         }
         // Write your data to the file
-        file << curr_time << "," << std::string(func).substr(0, id) << "," << "success" << std::endl;
+        //file << curr_time << "," << std::string(func).substr(0, id) << "," << "success" << std::endl;
+        file << curr_time << "," << std::string(func).substr(0, id) << "," \
+        << "succeed" << "," << condstr << "," << std::string(filename) <<"," \
+        << std::to_string(fileline) <<std::endl;
         file.close();
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,7 +129,7 @@ add_executable(
     test_trsm_device.cc
 )
 
-file(GLOB HELPHH ${PROJECT_SOURCE_DIR}/test/helper* lapack_wrappers.cc)
+file(GLOB HELPHH ${PROJECT_SOURCE_DIR}/test/helper/helper*  helper.hh helper.cc lapack_wrappers.cc)
 
 add_executable(helper ${HELPHH}) 
 

--- a/test/helper.cc
+++ b/test/helper.cc
@@ -45,10 +45,20 @@ enum SectionHelp {
 };
 
 std::vector< routines_help_t > routines = {
-    {"test1", helper_test1, SectionHelp::test1},
-    {"test2", helper_test2, SectionHelp::test1},
+    {"example_test1", helper_test1, SectionHelp::test1},
+    {"example_test2", helper_test2, SectionHelp::test1},
+    {"cublassetstream", helper_cublasSetStream, SectionHelp::test1},
+    {"cublasgetstream", helper_cublasGetStream, SectionHelp::test1},
+    {"cublassetvector", helper_cublasSetVector, SectionHelp::test1},
     { "", nullptr, SectionHelp::newline},
 };
+
+void print_routine_name(std::vector< routines_help_t >& routines){
+        for (size_t i = 0; i < routines.size(); ++i) {
+            printf("%-35s",routines[i].name);
+            if((i+1)%2==0) printf("\n");
+    }
+}
 
 int main( int argc, char** argv )
 {
@@ -56,14 +66,15 @@ int main( int argc, char** argv )
         || strcmp( argv[argc-1], "-h" ) == 0
         || strcmp( argv[argc-1], "--help" ) == 0)
     {
-        printf(" please test1 or test2\n");
+        printf("Please enter the following routine: \n");
+        print_routine_name(routines);
         return 0;
     }
     const char* routine = argv[ argc-1 ];
     test_help_func_ptr test_help_routine = find_help_tester( routine, routines );
     if(test_help_routine ==nullptr){
-        printf("input routine name error!\n");
-        printf("please input test1 or testxxx\n");
+        printf("input routine name error! Please enter the following routine: \n");
+        print_routine_name(routines);
         return 0;
     }
     try{
@@ -73,7 +84,5 @@ int main( int argc, char** argv )
         fprintf( stderr, "%s%sError: %s%s\n",
                   ansi_bold, ansi_red, ex.what(), ansi_normal );
     }
-    
-
-  return 0;
+    return 0;
 }

--- a/test/helper.hh
+++ b/test/helper.hh
@@ -39,4 +39,65 @@ bool check_return_status(cublasStatus_t device_status, const char* excpet_status
     return false;
 }
 
+class TestId{
+    public:
+        int test_id;
+        int all_testcase;
+        std::string param_name;
+        std::vector<std::string> params_name;
+    public:
+        TestId(){}
+        TestId(int all_testcase_, std::string param_name_){
+            all_testcase = all_testcase_;
+            param_name = param_name_;
+            test_id = 0;
+            param_parse();
+        }
+        TestId(int all_testcase_, std::string param_name_, int id){
+            all_testcase = all_testcase_;
+            param_name = param_name_;
+            test_id = id;
+            param_parse();
+        }
+
+        void TestProblemHeader(int param_id, bool flag=false, const char* inputvalue = nullptr){
+            test_id++;
+            if(flag) printf("[%d/%d] When all parameters are legal\n",test_id, all_testcase);
+            else printf("[%d/%d] When params %d \"%s\" is \"%s\"\n",test_id, all_testcase, param_id, params_name[param_id].c_str(), inputvalue);
+        }
+
+        void TestApiHeader(){
+            int len = param_name.length();
+            int pre=0, param_id=0;
+            for(int i=0; i<len; i++)
+            {
+                if(param_name[i]=='('){
+                    printf("We will test the %s api, its parameters are:\n", (param_name.substr(pre, i-pre)).c_str());
+                    pre = i+1;break;
+                }
+                // if(params[i]==' '){ pre=i+1;}
+                // if(params[i]==','|| params[i]==')'){
+                //     printf("param %d: %s  ", param_id++, (s.substr(pre, i-pre)).c_str());
+                //     pre=i+1;
+                // }
+            }
+            printf("%s\n", param_name.c_str());
+        }
+
+        void param_parse(){
+            int len = param_name.length();
+            params_name.clear();
+            int pre=0;
+            for(int i=0; i<len; i++){
+                if(param_name[i]=='('){pre=i+1;}
+                if(param_name[i]==' '){pre=i+1;}
+                if(param_name[i]==','|| param_name[i]==')'){
+                    params_name.push_back(param_name.substr(pre, i-pre));
+                    pre=i+1;
+                }
+            }
+        }
+};
+
+
 #endif

--- a/test/helper.hh
+++ b/test/helper.hh
@@ -5,11 +5,38 @@
 #include "testsweeper.hh"
 #include "blas.hh"
 
-
 using llong = long long;
+
+#include "cblas_wrappers.hh"
+#include "lapack_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include "check_gemm.hh"
+#include  "../src/device_internal.hh"
+
+
+void helper_cublasSetStream();
+void helper_cublasGetStream();
+void helper_cublasSetVector();
+
 
 
 void helper_test1();
 void helper_test2();
+
+
+inline
+bool check_return_status(cublasStatus_t device_status, const char* excpet_status, int &all_tests, int &passed_tests, int &failed_test)
+{
+    const char* device_status_name = blas::device_errorstatus_to_string(device_status);
+    all_tests++;
+    if(strcmp(device_status_name, excpet_status)==0){
+        passed_tests++;
+        return true;
+    }
+    //printf("API %s, Error status: %s Except error status: %s\n",api_name, device_status_name, excpet_status);
+    failed_test++;
+    return false;
+}
 
 #endif

--- a/test/helper/helper_cublasgetstream.cc
+++ b/test/helper/helper_cublasgetstream.cc
@@ -2,12 +2,16 @@
 
 void helper_cublasGetStream()
 {
+    //number of all cases, start id(Default is 0)
+    TestId CaseId(2, std::string("cublasGetStream(cublasHandle_t handle, cudaStream_t *streamId)"));
+    CaseId.TestApiHeader();
+
     int All_tests = 0;
     int Passed_tests = 0;
     int Failed_tests = 0;
     bool status;
     cublasStatus_t stat;
-    printf("This routine will test cublasGetStream API\n");
+    //printf("This routine will test cublasGetStream API\n");
     int64_t device = 0;
     if (blas::get_device_count() == 0) {
         printf("skipping: no GPU devices or no GPU support\n");
@@ -24,11 +28,13 @@ void helper_cublasGetStream()
     
     cudaStream_t test_stream;
     //test case 1:Test parameter 2 is an invalid parameter  
+    CaseId.TestProblemHeader(1, false, "NULL");
     stat = cublasGetStream( handle, NULL);
-    HelperTestCall("cublasGetStream", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasGetStream", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_INVALID_VALUE");
     //test case 2:This is a legal parameter input
+    CaseId.TestProblemHeader(0, true);
     stat = cublasGetStream( handle, &test_stream);
-    HelperTestCall("cublasGetStream", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasGetStream", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
 
 
 

--- a/test/helper/helper_cublasgetstream.cc
+++ b/test/helper/helper_cublasgetstream.cc
@@ -1,0 +1,39 @@
+#include "../helper.hh"
+
+void helper_cublasGetStream()
+{
+    int All_tests = 0;
+    int Passed_tests = 0;
+    int Failed_tests = 0;
+    bool status;
+    cublasStatus_t stat;
+    printf("This routine will test cublasGetStream API\n");
+    int64_t device = 0;
+    if (blas::get_device_count() == 0) {
+        printf("skipping: no GPU devices or no GPU support\n");
+        return;
+    }
+    HelperSafeCall( cudaSetDevice( device ) );
+    cudaStream_t stream;
+    HelperSafeCall( cudaStreamCreate( &stream ) );
+
+    cublasHandle_t handle;
+    HelperSafeCall(cublasCreate( &handle ));
+    
+    HelperSafeCall(cublasSetStream( handle, stream));
+    
+    cudaStream_t test_stream;
+    //test case 1:Test parameter 2 is an invalid parameter  
+    stat = cublasGetStream( handle, NULL);
+    HelperTestCall("cublasGetStream", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+    //test case 2:This is a legal parameter input
+    stat = cublasGetStream( handle, &test_stream);
+    HelperTestCall("cublasGetStream", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat);
+
+
+
+    printf("All test cases: %d Passed test cases: %d Failed test cases: %d\n", All_tests, Passed_tests, Failed_tests);
+    
+    cublasDestroy(handle);
+    cudaStreamDestroy(stream);
+}

--- a/test/helper/helper_cublassetstream.cc
+++ b/test/helper/helper_cublassetstream.cc
@@ -2,13 +2,15 @@
 
 void helper_cublasSetStream()
 {
+    TestId CaseId(1, std::string("cublasSetStream(cublasHandle_t handle, cudaStream_t streamId)"));
+    CaseId.TestApiHeader();
     int All_tests = 0;
     int Passed_tests = 0;
     int Failed_tests = 0;
     bool status;
     cublasStatus_t stat;
 
-    printf("This routine will test cublasSetStream API\n");
+    //printf("This routine will test cublasSetStream API\n");
     int64_t device = 0;
     if (blas::get_device_count() == 0) {
         printf("skipping: no GPU devices or no GPU support\n");
@@ -28,8 +30,9 @@ void helper_cublasSetStream()
     //status = check_return_status("cublasSetStream", cublasSetStream( handle, ), "CUBLAS_STATUS_NOT_INITIALIZED", All_tests, Passed_tests, Failed_tests);
 
     //test case 2: This is a legal parameter input
+    CaseId.TestProblemHeader(0, true);
     stat = cublasSetStream( handle, stream );
-    HelperTestCall("cublasSetStream", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasSetStream", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
     
     printf("All test cases: %d Passed test cases: %d Failed test cases: %d\n", All_tests, Passed_tests, Failed_tests);
 

--- a/test/helper/helper_cublassetstream.cc
+++ b/test/helper/helper_cublassetstream.cc
@@ -1,0 +1,39 @@
+#include "../helper.hh"
+
+void helper_cublasSetStream()
+{
+    int All_tests = 0;
+    int Passed_tests = 0;
+    int Failed_tests = 0;
+    bool status;
+    cublasStatus_t stat;
+
+    printf("This routine will test cublasSetStream API\n");
+    int64_t device = 0;
+    if (blas::get_device_count() == 0) {
+        printf("skipping: no GPU devices or no GPU support\n");
+        return;
+    }
+    HelperSafeCall( cudaSetDevice( device ) );
+
+
+    cudaStream_t stream;
+    HelperSafeCall( cudaStreamCreate( &stream ) );
+
+
+    cublasHandle_t handle;
+    HelperSafeCall(cublasCreate( &handle ));
+
+    //test case 1: Test the return status when cublas is not initialized
+    //status = check_return_status("cublasSetStream", cublasSetStream( handle, ), "CUBLAS_STATUS_NOT_INITIALIZED", All_tests, Passed_tests, Failed_tests);
+
+    //test case 2: This is a legal parameter input
+    stat = cublasSetStream( handle, stream );
+    HelperTestCall("cublasSetStream", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat);
+    
+    printf("All test cases: %d Passed test cases: %d Failed test cases: %d\n", All_tests, Passed_tests, Failed_tests);
+
+
+    cublasDestroy(handle);
+    cudaStreamDestroy(stream);
+}

--- a/test/helper/helper_cublassetvector.cc
+++ b/test/helper/helper_cublassetvector.cc
@@ -1,0 +1,74 @@
+#include "../helper.hh"
+
+void helper_cublasSetVector()
+{
+    int All_tests = 0;
+    int Passed_tests = 0;
+    int Failed_tests = 0;
+    bool status;
+    cublasStatus_t stat;
+    printf("This routine will test cublasSetVector API\n");
+    int64_t device = 0;
+    if (blas::get_device_count() == 0) {
+        printf("skipping: no GPU devices or no GPU support\n");
+        return;
+    }
+    HelperSafeCall( cudaSetDevice( device ) );
+    cudaStream_t stream;
+    HelperSafeCall( cudaStreamCreate( &stream ) );
+
+    cublasHandle_t handle;
+    HelperSafeCall(cublasCreate( &handle ));
+    
+    HelperSafeCall(cublasSetStream( handle, stream));
+    
+    int64_t n = 100;
+    int64_t incx = 1;
+    size_t size_x = (n - 1) * std::abs(incx) + 1;
+
+
+    float *x, *xcopy;
+    x = new float[ size_x ];
+    xcopy = new float[ size_x ];
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    //init data
+    lapack_larnv( idist, iseed, size_x, x );
+
+    float *dx;
+    HelperSafeCall(cudaMalloc((float**)&dx, size_x*sizeof(float)));
+
+    //test case 1: legal parameters
+    stat = cublasSetVector(size_x, sizeof(float), x, incx, dx, incx);
+    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat);
+    
+    HelperSafeCall(cudaMemcpy(xcopy, dx, size_x*sizeof(float),cudaMemcpyDeviceToHost));
+    //HelperSafeCall(cublasGetVector(size_x, sizeof(float), dx, incx, xcopy, incx));
+    for(int i=0; i<n; i++){
+        if(x[i*incx]!=xcopy[i*incx]){
+            printf("cublasSetVector or cublasGetVector error\n");
+            Passed_tests--;
+            Failed_tests++;
+            break;
+        }
+    }
+
+    //test case 2: Testing for illegal parameter elemSize
+    stat = cublasSetVector(size_x, -1, x, incx, dx, incx);
+    HelperTestCall("cublasSetVector", check_return_status(stat , "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+
+    //test case 3: Testing for illegal parameter incx
+    stat = cublasSetVector(size_x, sizeof(float), x, -1, dx, incx);
+    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+
+    //test case 4: Testing for illegal parameter incy
+    stat = cublasSetVector(size_x, sizeof(float), x, incx, dx, -1);
+    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+
+
+    printf("All test cases: %d Passed test cases: %d Failed test cases: %d\n", All_tests, Passed_tests, Failed_tests);
+    
+
+    cublasDestroy(handle);
+    cudaStreamDestroy(stream);
+}

--- a/test/helper/helper_cublassetvector.cc
+++ b/test/helper/helper_cublassetvector.cc
@@ -2,12 +2,14 @@
 
 void helper_cublasSetVector()
 {
+    TestId CaseId(4, std::string("cublasSetVector(int n, int elemSize, const void *x, int incx, void *y, int incy)"));
+    CaseId.TestApiHeader();
     int All_tests = 0;
     int Passed_tests = 0;
     int Failed_tests = 0;
     bool status;
     cublasStatus_t stat;
-    printf("This routine will test cublasSetVector API\n");
+    //printf("This routine will test cublasSetVector API\n");
     int64_t device = 0;
     if (blas::get_device_count() == 0) {
         printf("skipping: no GPU devices or no GPU support\n");
@@ -39,8 +41,9 @@ void helper_cublasSetVector()
     HelperSafeCall(cudaMalloc((float**)&dx, size_x*sizeof(float)));
 
     //test case 1: legal parameters
+    CaseId.TestProblemHeader(0, true);
     stat = cublasSetVector(size_x, sizeof(float), x, incx, dx, incx);
-    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
     
     HelperSafeCall(cudaMemcpy(xcopy, dx, size_x*sizeof(float),cudaMemcpyDeviceToHost));
     //HelperSafeCall(cublasGetVector(size_x, sizeof(float), dx, incx, xcopy, incx));
@@ -54,16 +57,19 @@ void helper_cublasSetVector()
     }
 
     //test case 2: Testing for illegal parameter elemSize
+    CaseId.TestProblemHeader(1,false, "-1");
     stat = cublasSetVector(size_x, -1, x, incx, dx, incx);
-    HelperTestCall("cublasSetVector", check_return_status(stat , "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasSetVector", check_return_status(stat , "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_INVALID_VALUE");
 
     //test case 3: Testing for illegal parameter incx
+    CaseId.TestProblemHeader(3, false, "-1");
     stat = cublasSetVector(size_x, sizeof(float), x, -1, dx, incx);
-    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_INVALID_VALUE");
 
     //test case 4: Testing for illegal parameter incy
+    CaseId.TestProblemHeader(5, false, "-1");
     stat = cublasSetVector(size_x, sizeof(float), x, incx, dx, -1);
-    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat);
+    HelperTestCall("cublasSetVector", check_return_status(stat, "CUBLAS_STATUS_INVALID_VALUE", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_INVALID_VALUE");
 
 
     printf("All test cases: %d Passed test cases: %d Failed test cases: %d\n", All_tests, Passed_tests, Failed_tests);

--- a/test/helper/helper_test1.cc
+++ b/test/helper/helper_test1.cc
@@ -1,9 +1,4 @@
-#include "helper.hh"
-#include "lapack_wrappers.hh"
-#include "cblas_wrappers.hh"
-#include "blas/flops.hh"
-#include "print_matrix.hh"
-#include  "../src/device_internal.hh"
+#include "../helper.hh"
 
 // typedef void (*test_log_func_ptr)(void* userData, cublasStatus_t status, const char* msg);
 

--- a/test/helper/helper_test2.cc
+++ b/test/helper/helper_test2.cc
@@ -1,10 +1,4 @@
-#include "helper.hh"
-#include "cblas_wrappers.hh"
-#include "lapack_wrappers.hh"
-#include "blas/flops.hh"
-#include "print_matrix.hh"
-#include "check_gemm.hh"
-#include  "../src/device_internal.hh"
+#include "../helper.hh"
 
 void helper_test2()
 {
@@ -66,12 +60,12 @@ void helper_test2()
     //test cublasGetStatusString
     printf("Test cublasGetStatusString: %s\n",cublasGetStatusString(cublasGetProperty(PATCH_LEVEL, &value)));
 
-    // size_t workspace_size = 128;
-    // float *workspace;
-    // HelperSafeCall(cudaMalloc((float**)&workspace, workspace_size*sizeof(float)) );
-    // cublasStatus_t err = cublasSetWorkspace(handle, (float*)workspace, workspace_size*sizeof(float));
-    // HelperSafeCall(err);
-    // printf("Test cublasSetWorkspace: %s\n",cublasGetStatusName(err));
+    size_t workspace_size = 128;
+    float *workspace;
+    HelperSafeCall(cudaMalloc((float**)&workspace, workspace_size*sizeof(float)) );
+    cublasStatus_t err = cublasSetWorkspace(handle, (float*)workspace, workspace_size*sizeof(float));
+    HelperSafeCall(err);
+    printf("Test cublasSetWorkspace: %s\n",cublasGetStatusName(err));
     
     size_t size_A = m * k;
     size_t size_B = n * k;

--- a/test/helper/helper_test2.cc
+++ b/test/helper/helper_test2.cc
@@ -60,12 +60,12 @@ void helper_test2()
     //test cublasGetStatusString
     printf("Test cublasGetStatusString: %s\n",cublasGetStatusString(cublasGetProperty(PATCH_LEVEL, &value)));
 
-    size_t workspace_size = 128;
-    float *workspace;
-    HelperSafeCall(cudaMalloc((float**)&workspace, workspace_size*sizeof(float)) );
-    cublasStatus_t err = cublasSetWorkspace(handle, (float*)workspace, workspace_size*sizeof(float));
-    HelperSafeCall(err);
-    printf("Test cublasSetWorkspace: %s\n",cublasGetStatusName(err));
+    // size_t workspace_size = 128;
+    // float *workspace;
+    // HelperSafeCall(cudaMalloc((float**)&workspace, workspace_size*sizeof(float)) );
+    // cublasStatus_t err = cublasSetWorkspace(handle, (float*)workspace, workspace_size*sizeof(float));
+    // HelperSafeCall(err);
+    // printf("Test cublasSetWorkspace: %s\n",cublasGetStatusName(err));
     
     size_t size_A = m * k;
     size_t size_B = n * k;

--- a/test/test_gemm_device.cc
+++ b/test/test_gemm_device.cc
@@ -109,65 +109,65 @@ void test_gemm_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //case 1: Test transA is an illegal value
         blas::gemm( layout,    Op(0),  transB,  m,  n,  k, alpha, dA, lda, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 2: Test transA is an illegal value
         blas::gemm( layout,    transA, Op(0),   m,  n,  k, alpha, dA, lda, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 3: Test the return value when m is an illegal value
         blas::gemm( layout,    transA, transB, -1,  n,  k, alpha, dA, lda, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 4: Test the return value when n is an illegal value
         blas::gemm( layout,    transA, transB,  m, -1,  k, alpha, dA, lda, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 5: Test the return value when k is an illegal value
         blas::gemm( layout,    transA, transB,  m,  n, -1, alpha, dA, lda, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 6: Test the return value when lda is an illegal value and tansA is NoTrans
         blas::gemm( Layout::ColMajor, Op::NoTrans,   Op::NoTrans, m, n, k, alpha, dA, m-1, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 7: Test the return value when lda is an illegal value and tansA is Trans
         blas::gemm( Layout::ColMajor, Op::Trans,     Op::NoTrans, m, n, k, alpha, dA, k-1, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 8: Test the return value when lda is an illegal value and tansA is ConjTrans
         blas::gemm( Layout::ColMajor, Op::ConjTrans, Op::NoTrans, m, n, k, alpha, dA, k-1, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
 
         //case 9: Test the return value when row-major order, tansA=NoTrans, and lda is an illegal value
         blas::gemm( Layout::RowMajor, Op::NoTrans,   Op::NoTrans, m, n, k, alpha, dA, k-1, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 10: Test the return value when row-major order, tansA=Trans, and lda is an illegal value
         blas::gemm( Layout::RowMajor, Op::Trans,     Op::NoTrans, m, n, k, alpha, dA, m-1, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 11: Test the return value when row-major order, tansA=ConjTrans, and lda is an illegal value
         blas::gemm( Layout::RowMajor, Op::ConjTrans, Op::NoTrans, m, n, k, alpha, dA, m-1, dB, ldb, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
 
         //case 12: Test the return value when col-major order, tansB=NoTrans, ldb is an illegal value
         blas::gemm( Layout::ColMajor, Op::NoTrans, Op::NoTrans,   m, n, k, alpha, dA, lda, B, k-1, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 13: Test the return value when col-major order, tansB=Trans, ldb is an illegal value
         blas::gemm( Layout::ColMajor, Op::NoTrans, Op::Trans,     m, n, k, alpha, dA, lda, B, n-1, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 14: Test the return value when col-major order, tansB=ConjTrans, ldb is an illegal value
         blas::gemm( Layout::ColMajor, Op::NoTrans, Op::ConjTrans, m, n, k, alpha, dA, lda, B, n-1, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
 
         //case 15: Test the return value when row-major order, tansB=NoTrans, ldb is an illegal value
         blas::gemm( Layout::RowMajor, Op::NoTrans, Op::NoTrans,   m, n, k, alpha, dA, lda, B, n-1, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 16: Test the return value when row-major order, tansB=Trans, ldb is an illegal value
         blas::gemm( Layout::RowMajor, Op::NoTrans, Op::Trans,     m, n, k, alpha, dA, lda, B, k-1, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 17: Test the return value when row-major order, tansB=ConjTrans, ldb is an illegal value
         blas::gemm( Layout::RowMajor, Op::NoTrans, Op::ConjTrans, m, n, k, alpha, dA, lda, B, k-1, beta, dC, ldc, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
 
         //case 18: Test the return value when col-major order, ldc is an illegal value
         blas::gemm( Layout::ColMajor, transA, transB, m, n, k, alpha, dA, lda, dB, ldb, beta, dC, m-1, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name );
         //case 19: Test the return value when row-major order, ldc is an illegal value
         blas::gemm( Layout::RowMajor, transA, transB, m, n, k, alpha, dA, lda, dB, ldb, beta, dC, n-1, queue, testcase, error_name );
-        result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name );
         queue.sync();
 
         printf("All Test Cases: %d  Passed Cases: %d  Failed Cases: %d\n",all_testcase, passed_testcase, failed_testcase);


### PR DESCRIPTION
### 1、增加gemm 非法参数输入时的log日志，以方便追踪。
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/2f4c7714-f4a0-4005-8f8d-fe88706f965a)
### 2、重新调整helper类测试方式，增加log记录和打印输出的格式。
目前有5个可输入的routine
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/d66e2e11-5b5b-4b74-8a78-e0c872812cc4)

以cublassetvector为例，输出结果为：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/f0b31e48-3e3b-405e-99fd-8f7e85529059)

对应的日志为：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/6fb3cca2-1ecf-4ac1-a75e-e8c0883ef1c9)


