### PR TITLE
修复amax、amin、asum和axpy四个算子在incx为负数时的failed问题，增加异常测试case

### DIFF
--- a/test/test_amax_device.cc
+++ b/test/test_amax_device.cc
@@ -61,7 +61,20 @@ void test_amax_device_work( Params& params, bool run )
         //Test case 1: Test result is an nullptr
         blas::amax( n, dx, incx, nullptr, queue, testcase, error_name);
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
+        //Test case 2: Test n is 0
+        blas::amax( 0, dx, incx, &result, queue, testcase, error_name);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        //Test case 3: Test n is -1
+        blas::amax( -1, dx, incx, &result, queue, testcase, error_name);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        //Test case 4: Test incx is 0
+        blas::amax( n, dx, 0, &result, queue, testcase, error_name);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        //Test case 5: Test incx is -1
+        blas::amax( n, dx, -1, &result, queue, testcase, error_name);
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
 
+        queue.sync();
         printf("All Test Cases: %d  Passed Cases: %d  Failed Cases: %d\n",all_testcase, passed_testcase, failed_testcase);
         free(error_name);
     }
@@ -95,7 +108,7 @@ void test_amax_device_work( Params& params, bool run )
             time = get_wtime();
             int64_t ref = cblas_iamax( n, x, incx );
             time = get_wtime() - time;
-            ref += 1;
+            if(n>0 && incx>0) ref += 1;
             //printf( "result_dev = %5lld cblas= %5lld\n", llong( result ),llong(ref) );
             params.ref_time()   = time * 1000;  // msec
             params.ref_gflops() = gflop / time;

--- a/test/test_amin_device.cc
+++ b/test/test_amin_device.cc
@@ -64,8 +64,20 @@ void test_amin_device_work( Params& params, bool run )
         //case 1: Test the return value when result is a nullptr
         blas::amin( n, dx, incx, nullptr, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
-        queue.sync();
+        //case 2: Test n is 0
+        blas::amin( 0, dx, incx, &result, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        //case 3: Test n is -1
+        blas::amin( -1, dx, incx, &result, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        //case 4: Test incx is 0
+        blas::amin( n, dx, 0, &result, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        //case 5: Test incx is -1
+        blas::amin( n, dx, -1, &result, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
 
+        queue.sync();
         printf("All Test Cases: %d  Passed Cases: %d  Failed Cases: %d\n",all_testcase, passed_testcase, failed_testcase);
 
         free(error_name);
@@ -99,7 +111,7 @@ void test_amin_device_work( Params& params, bool run )
             time = get_wtime();
             int64_t ref = cblas_iamin( n, x, incx );
             time = get_wtime() - time;
-            ref += 1;
+            if(n>0 && incx>0) ref += 1;
             //printf( "result_dev = %5lld cblas= %5lld\n", llong( result ),llong(ref) );
             params.ref_time()   = time * 1000;  // msec
             params.ref_gflops() = gflop / time;

--- a/test/test_asum_device.cc
+++ b/test/test_asum_device.cc
@@ -67,16 +67,16 @@ void test_asum_device_work( Params& params, bool run )
         //case 1: Test the return value when result is a nullptr
         blas::asum( n, dx, incx, nullptr, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
-        //case 1: Test the n is 0
+        //case 2: Test the n is 0
         blas::asum( 0, dx, incx, &result_device, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
-        //case 1: Test the n is -1
+        //case 3: Test the n is -1
         blas::asum( -1, dx, incx, &result_device, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
-        //case 1: Test the incx is 0
+        //case 4: Test the incx is 0
         blas::asum( n, dx, 0, &result_device, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
-        //case 1: Test the incx is -1
+        //case 5: Test the incx is -1
         blas::asum( n, dx, -1, &result_device, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
         queue.sync();

--- a/test/test_asum_device.cc
+++ b/test/test_asum_device.cc
@@ -67,8 +67,19 @@ void test_asum_device_work( Params& params, bool run )
         //case 1: Test the return value when result is a nullptr
         blas::asum( n, dx, incx, nullptr, queue, testcase, error_name );
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
+        //case 1: Test the n is 0
+        blas::asum( 0, dx, incx, &result_device, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
+        //case 1: Test the n is -1
+        blas::asum( -1, dx, incx, &result_device, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
+        //case 1: Test the incx is 0
+        blas::asum( n, dx, 0, &result_device, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
+        //case 1: Test the incx is -1
+        blas::asum( n, dx, -1, &result_device, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
         queue.sync();
-
         printf("All Test Cases: %d  Passed Cases: %d  Failed Cases: %d\n",all_testcase, passed_testcase, failed_testcase);
 
         free(error_name);
@@ -89,8 +100,9 @@ void test_asum_device_work( Params& params, bool run )
         queue.sync();
         //time = get_wtime() - time;
         //copy data from gpu to cpu
-        blas::device_copy_vector(1, &result_device, 1, &result_host, 1, queue);
-        queue.sync();
+        result_host = result_device;
+        // blas::device_copy_vector(1, &result_device, 1, &result_host, 1, queue);
+        // queue.sync();
         double gflop = blas::Gflop< T >::asum( n );
         double gbyte = blas::Gbyte< T >::asum( n );
         // params.time()   = time * 1000;  // msec

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -77,10 +77,32 @@ void test_axpy_device_work( Params& params, bool run )
 
     // test error exits
     if(testcase == 0){
-        //The number of test cases is 0
+        //The number of test cases is 2
+        char *error_name = (char *)malloc(sizeof(char)*35);
         int all_testcase = 0;
         int passed_testcase = 0;
         int failed_testcase = 0;
+        //case1: test n is 0
+        blas::axpy( 0, alpha, dx, incx, dy, incy, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+        //case2: test n is -1
+        blas::axpy( -1, alpha, dx, incx, dy, incy, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+        //case3: test incx is 0
+        blas::axpy( n, alpha, dx, 0, dy, incy, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+        //case4: test incx is -1
+        blas::axpy( n, alpha, dx, -1, dy, incy, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+
+        //case5: test incy is 0
+        blas::axpy( n, alpha, dx, incx, dy, 0, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+
+        //case6: test incy is -1
+        blas::axpy( n, alpha, dx, incx, dy, -1, queue, testcase, error_name );
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+
         printf("All Test Cases: %d  Passed Cases: %d  Failed Cases: %d\n",all_testcase, passed_testcase, failed_testcase);
     }
     else{


### PR DESCRIPTION
amax算子：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/0160b4ce-0904-4724-a4f9-45e6a9d7ab98)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/85ba13b0-78db-4c39-bbf3-63343b0d5232)

amin算子：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/e47dd477-9ad0-4cc4-bb11-427c0333471f)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/ce8b8602-8773-47c0-9882-ea0c5690bb5d)


asum算子：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/7cd058fd-f7c5-4d67-bf31-a694d1801e31)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/169810cf-0cd1-46a6-8681-cc6234511129)


axpy算子：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/082a95a0-1d6d-4d9d-94d1-999b66ad8995)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/eac07d73-6fe5-4085-bfaf-404008670bbf)


