### PR TITLE
修复gemv incx不等于1时程序出错的问题

### DIFF
--- a/src/device_gemv.cc
+++ b/src/device_gemv.cc
@@ -86,26 +86,25 @@ void gemv(
             if (trans == Op::ConjTrans) {
                 alpha = conj( alpha );
                 beta  = conj( beta );
-
                 //x2 = new scalar_t[ m ];
-                scalar_t* x_host = new scalar_t[ m ];
+                scalar_t* x_host = new scalar_t[ m * std::abs(incx)];
                 blas::device_copy_vector(m, x, std::abs(incx), x_host, std::abs(incx),queue);
                 queue.sync();
-                scalar_t* x2_host = new scalar_t[ m ];
-                x2 = blas::device_malloc<scalar_t>( m, queue );
+                scalar_t* x2_host = new scalar_t[ m * std::abs(incx)];
+                x2 = blas::device_malloc<scalar_t>( m* std::abs(incx), queue );
                 int64_t ix = (incx > 0 ? 0 : (-m + 1)*incx);
                 for (int64_t i = 0; i < m; ++i) {
-                    x2_host[ i ] = conj( x_host [ ix ]);
+                    x2_host[ ix ] = conj( x_host [ ix ]);
                     ix += incx;
                     //x2[ i ] = conj( x[ ix ] );
                 }
-                incx_ = 1;
+                //incx_ = 1;
                 blas::device_copy_vector(m, x2_host, std::abs(incx), x2, std::abs(incx), queue);
                 queue.sync();
                 delete[] x_host;
                 delete[] x2_host;
 
-                scalar_t* y1_host = new scalar_t[ n ];
+                scalar_t* y1_host = new scalar_t[ n * std::abs(incy) ];
                 blas::device_copy_vector(n, y, std::abs(incy), y1_host, std::abs(incy),queue);
                 queue.sync();
                 int64_t iy = (incy > 0 ? 0 : (-n + 1)*incy);
@@ -132,7 +131,7 @@ void gemv(
     if constexpr (is_complex<scalar_t>::value) {
         if (x2 != x) {  // RowMajor ConjTrans
             // y = conj( y )
-            scalar_t* y2_host = new scalar_t[ n ];
+            scalar_t* y2_host = new scalar_t[ n*std::abs(incy) ];
             blas::device_copy_vector(n, y, std::abs(incy), y2_host, std::abs(incy),queue);
             queue.sync();
             int64_t iy = (incy > 0 ? 0 : (-n + 1)*incy);


### PR DESCRIPTION
修复gemv incx不等于1时程序出错的问题

![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/1a9f414a-39d7-4807-820d-c6d6ccf325ee)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/458bd47c-4889-4e16-abfc-09c28e03e92d)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/b5a77ef6-b8bc-49c3-8fdf-7c770fece415)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/6ef735b0-cfc4-4bd2-a8c0-e0f1b9f7cb87)
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/ad850463-3ab1-421a-bacb-d53495e98e3e)

