### PR TITLE
修复helper类两个bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When users use it, they only need to cd to the directory and run the following c
 bash test_levelxxx_xxx.sh
 ```
 
-### License
+## License
 
 Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,25 @@ make -j4
 ./tester [parameters] routine
 ```
 
+5、Test via script
+We also wrote a shell script, which contains test cases. The shell script is in the two directories test_scripts/correctness and test_scripts/performance, which represent correctness testing and performance testing respectively.
+When users use it, they only need to cd to the directory and run the following command:
+```
+bash test_levelxxx_xxx.sh
+```
+
+### License
+
+Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    * Neither the name of the University of Tennessee nor the
+      names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright holders or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.

--- a/test/helper/helper_cublasgetloggercallback.cc
+++ b/test/helper/helper_cublasgetloggercallback.cc
@@ -1,5 +1,9 @@
 #include "../helper.hh"
 
+void calfun2(cublasStatus_t status, const char* message){
+    //printf("log write=%s\n",blas::device_errorstatus_to_string(status));
+}
+
 void helper_cublasGetLoggerCallback()
 {
     TestId CaseId(2, std::string("cublasGetLoggerCallback(cublasLogCallback* userCallback)"));
@@ -24,10 +28,11 @@ void helper_cublasGetLoggerCallback()
     
     HelperSafeCall(cublasSetStream( handle, stream));
 
-    cublasLogCallback calfunc;
+    cublasLogCallback calfunc = nullptr;
 
     //test case 1: legal parameters
     CaseId.TestProblemHeader(0, true);
+    HelperSafeCall(cublasSetLoggerCallback((cublasLogCallback)calfun2));
     stat = cublasGetLoggerCallback(&calfunc);
     HelperTestCall("cublasGetLoggerCallback", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
 

--- a/test/helper/helper_cublasgetmatrix.cc
+++ b/test/helper/helper_cublasgetmatrix.cc
@@ -48,13 +48,15 @@ void helper_cublasGetMatrix()
     CaseId.TestProblemHeader(0, true);
     stat = cublasGetMatrix(rows, cols, elemSize, dA, lda, Acopy, ldb);
     HelperTestCall("cublasGetMatrix", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
-    for (int i = 0; i < cols; i++) {
-        for (int j = 0; j < rows; j++) {
-            if (A[i * lda + j] != Acopy[i * ldb + j]) {
-                printf("cublasSetMatrix error\n");
-                Passed_tests--;
-                Failed_tests++;
-                break;
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
+        for (int i = 0; i < cols; i++) {
+            for (int j = 0; j < rows; j++) {
+                if (A[i * lda + j] != Acopy[i * ldb + j]) {
+                    printf("cublasSetMatrix error\n");
+                    Passed_tests--;
+                    Failed_tests++;
+                    break;
+                }
             }
         }
     }

--- a/test/helper/helper_cublasgetmatrixasync.cc
+++ b/test/helper/helper_cublasgetmatrixasync.cc
@@ -49,18 +49,18 @@ void helper_cublasGetMatrixAsync()
     stat = cublasGetMatrixAsync(rows, cols, elemSize, dA, lda, Acopy, ldb, stream);
     HelperTestCall("cublasGetMatrixAsync", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
     HelperSafeCall(cudaStreamSynchronize(stream));
-
-    for (int i = 0; i < cols; i++) {
-        for (int j = 0; j < rows; j++) {
-            if (A[i * lda + j] != Acopy[i * ldb + j]) {
-                printf("cublasSetMatrix error\n");
-                Passed_tests--;
-                Failed_tests++;
-                break;
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
+        for (int i = 0; i < cols; i++) {
+            for (int j = 0; j < rows; j++) {
+                if (A[i * lda + j] != Acopy[i * ldb + j]) {
+                    printf("cublasSetMatrix error\n");
+                    Passed_tests--;
+                    Failed_tests++;
+                    break;
+                }
             }
         }
     }
-
     //test case 2: Testing for illegal parameter rows
     CaseId.TestProblemHeader(0, false, "-1");
     stat = cublasGetMatrixAsync(-1, cols, elemSize, dA, lda, Acopy, ldb, stream);

--- a/test/helper/helper_cublasgetvector.cc
+++ b/test/helper/helper_cublasgetvector.cc
@@ -45,6 +45,7 @@ void helper_cublasGetVector()
     CaseId.TestProblemHeader(0, true);
     stat = cublasGetVector(size_x, sizeof(float), dx, incx, xcopy, incx);
     HelperTestCall("cublasGetVector", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
     for(int i=0; i<n; i++){
         if(x[i*incx]!=xcopy[i*incx]){
             printf("cublasGetVector error!\n");
@@ -53,7 +54,7 @@ void helper_cublasGetVector()
             break;
         }
     }
-
+    }
     //test case 2: Testing for illegal parameter elemSize
     CaseId.TestProblemHeader(1,false, "-1");
     stat = cublasGetVector(size_x, -1, dx, incx, xcopy, incx);

--- a/test/helper/helper_cublasgetvectorasync.cc
+++ b/test/helper/helper_cublasgetvectorasync.cc
@@ -47,7 +47,7 @@ void helper_cublasGetVectorAsync()
     stat = cublasGetVectorAsync(size_x, sizeof(float), dx, incx, xcopy, incx, stream);
     HelperTestCall("cublasGetVectorAsync", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
     HelperSafeCall(cudaStreamSynchronize(stream));
-
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
     for(int i=0; i<n; i++){
         if(x[i*incx]!=xcopy[i*incx]){
             printf("cublasGetVectorAsync error!\n");
@@ -56,7 +56,7 @@ void helper_cublasGetVectorAsync()
             break;
         }
     }
-
+    }
     //test case 2: Testing for illegal parameter elemSize
     CaseId.TestProblemHeader(1,false, "-1");
     stat = cublasGetVectorAsync(size_x, -1, dx, incx, xcopy, incx, stream);

--- a/test/helper/helper_cublassetloggercallback.cc
+++ b/test/helper/helper_cublassetloggercallback.cc
@@ -1,5 +1,9 @@
 #include "../helper.hh"
 
+void calfun(cublasStatus_t status, const char* message){
+    //printf("log write=%s\n",blas::device_errorstatus_to_string(status));
+}
+
 void helper_cublasSetLoggerCallback()
 {
     TestId CaseId(1, std::string("cublasSetLoggerCallback(cublasLogCallback userCallback)"));
@@ -24,11 +28,11 @@ void helper_cublasSetLoggerCallback()
     
     HelperSafeCall(cublasSetStream( handle, stream));
 
-    cublasLogCallback calfunc;
+    //cublasLogCallback calfunc;
 
     //test case 1: legal parameters
     CaseId.TestProblemHeader(0, true);
-    stat = cublasSetLoggerCallback(calfunc);
+    stat = cublasSetLoggerCallback((cublasLogCallback)calfun);
     HelperTestCall("cublasSetLoggerCallback", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
 
     printf("All test cases: %d Passed test cases: %d Failed test cases: %d\n", All_tests, Passed_tests, Failed_tests);

--- a/test/helper/helper_cublassetmatrix.cc
+++ b/test/helper/helper_cublassetmatrix.cc
@@ -48,6 +48,7 @@ void helper_cublasSetMatrix()
     HelperTestCall("cublasSetMatrix", check_return_status(stat, "CUBLAS_STATUS_SUCCESS", All_tests, Passed_tests, Failed_tests), stat, "CUBLAS_STATUS_SUCCESS");
 
     HelperSafeCall(cudaMemcpy(Acopy, dA, size_A * sizeof(float), cudaMemcpyDeviceToHost));
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
     for (int i = 0; i < cols; i++) {
         for (int j = 0; j < rows; j++) {
             if (A[i * lda + j] != Acopy[i * ldb + j]) {
@@ -58,7 +59,7 @@ void helper_cublasSetMatrix()
             }
         }
     }
-
+    }
     //test case 2: Testing for illegal parameter rows
     CaseId.TestProblemHeader(0, false, "-1");
     stat = cublasSetMatrix(-1, cols, elemSize, A, lda, dA, ldb);

--- a/test/helper/helper_cublassetmatrixasync.cc
+++ b/test/helper/helper_cublassetmatrixasync.cc
@@ -49,6 +49,7 @@ void helper_cublasSetMatrixAsync()
     HelperSafeCall(cudaStreamSynchronize(stream));
 
     HelperSafeCall(cudaMemcpy(Acopy, dA, size_A * sizeof(float), cudaMemcpyDeviceToHost));
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
     for (int i = 0; i < cols; i++) {
         for (int j = 0; j < rows; j++) {
             if (A[i * lda + j] != Acopy[i * ldb + j]) {
@@ -59,7 +60,7 @@ void helper_cublasSetMatrixAsync()
             }
         }
     }
-
+    }
     //test case 2: Testing for illegal parameter rows
     CaseId.TestProblemHeader(0, false, "-1");
     stat = cublasSetMatrixAsync(-1, cols, elemSize, A, lda, dA, ldb, stream);

--- a/test/helper/helper_cublassetvector.cc
+++ b/test/helper/helper_cublassetvector.cc
@@ -47,6 +47,7 @@ void helper_cublasSetVector()
     
     HelperSafeCall(cudaMemcpy(xcopy, dx, size_x*sizeof(float),cudaMemcpyDeviceToHost));
     //HelperSafeCall(cublasGetVector(size_x, sizeof(float), dx, incx, xcopy, incx));
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
     for(int i=0; i<n; i++){
         if(x[i*incx]!=xcopy[i*incx]){
             printf("cublasSetVector or cublasGetVector error\n");
@@ -55,7 +56,7 @@ void helper_cublasSetVector()
             break;
         }
     }
-
+    }
     //test case 2: Testing for illegal parameter elemSize
     CaseId.TestProblemHeader(1, false, "-1");
     stat = cublasSetVector(size_x, -1, x, incx, dx, incx);

--- a/test/helper/helper_cublassetvectorasync.cc
+++ b/test/helper/helper_cublassetvectorasync.cc
@@ -47,6 +47,7 @@ void helper_cublasSetVectorAsync()
     HelperSafeCall(cudaStreamSynchronize(stream));
 
     HelperSafeCall(cudaMemcpy(xcopy, dx, size_x*sizeof(float),cudaMemcpyDeviceToHost));
+    if(strcmp(blas::device_errorstatus_to_string(stat),"CUBLAS_STATUS_SUCCESS")==0){
     for(int i=0; i<n; i++){
         if(x[i*incx]!=xcopy[i*incx]){
             printf("cublasSetVectorAsync error!\n");
@@ -55,7 +56,7 @@ void helper_cublasSetVectorAsync()
             break;
         }
     }
-
+    }
     //test case 2: Testing for illegal parameter elemSize
     CaseId.TestProblemHeader(1,false, "-1");
     stat = cublasSetVectorAsync(size_x, -1, x, incx, dx, incx, stream);


### PR DESCRIPTION
Bug1:在3090上跑cublasSetLoggerCallback API的时候，出现段错误。经查，发现代码中传入的回调函数有问题
问题如下：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/fa55e2ef-37ac-497c-9d46-71ce27b892bf)
更正后：
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/298d411f-d589-4689-a6f0-eaf08de2df5e)

Bug2: 在数据拷贝类的API测试正确性时，不仅检查状态码还检查数据内容。目前的代码在返回状态码是错的，数据内容也是错误的情况下，统计结果不对。目前已修复。