### PR TITLE
修复部分一级算子非法参数测试case异常和判断条件异常问题

### DIFF
--- a/test/test.hh
+++ b/test/test.hh
@@ -150,10 +150,10 @@ double sync_get_wtime( blas::Queue& queue )
 }
 
 inline 
-bool result_match(const char *device_result,  const char *except_result, int &all, int &pass, int &failed){
+bool result_match(const char *device_result,  const char *except_result, int &all, int &pass, int &failed, bool iszero=true){
     //printf("error is: %s\n",device_result);
     all ++;
-    if(strcmp(device_result, except_result)==0){
+    if(iszero && strcmp(device_result, except_result)==0){
         pass ++;
         return true;
     }

--- a/test/test_amax_device.cc
+++ b/test/test_amax_device.cc
@@ -75,21 +75,25 @@ void test_amax_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //Test case 1: Test result is an nullptr
         blas::amax( n, dx, incx, nullptr, queue, testcase, error_name);
+        queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 2: Test n is 0
         blas::amax( 0, dx, incx, &result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
         //Test case 3: Test n is -1
         blas::amax( -1, dx, incx, &result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
         //Test case 4: Test incx is 0
         blas::amax( n, dx, 0, &result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
         //Test case 5: Test incx is -1
         blas::amax( n, dx, -1, &result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
-
         queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
+
         params.Totalcase()+=all_testcase;
         params.Passedcase()+=passed_testcase;
         params.Failedcase()+=failed_testcase;

--- a/test/test_amin_device.cc
+++ b/test/test_amin_device.cc
@@ -78,21 +78,25 @@ void test_amin_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //case 1: Test the return value when result is a nullptr
         blas::amin( n, dx, incx, nullptr, queue, testcase, error_name );
+        queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 2: Test n is 0
         blas::amin( 0, dx, incx, &result, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
         //case 3: Test n is -1
         blas::amin( -1, dx, incx, &result, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
         //case 4: Test incx is 0
         blas::amin( n, dx, 0, &result, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
         //case 5: Test incx is -1
         blas::amin( n, dx, -1, &result, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result==0, error_name);
-
         queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result==0), error_name);
+
         params.Totalcase()+=all_testcase;
         params.Passedcase()+=passed_testcase;
         params.Failedcase()+=failed_testcase;

--- a/test/test_asum_device.cc
+++ b/test/test_asum_device.cc
@@ -82,20 +82,25 @@ void test_asum_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //case 1: Test the return value when result is a nullptr
         blas::asum( n, dx, incx, nullptr, queue, testcase, error_name );
+        queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //case 2: Test the n is 0
         blas::asum( 0, dx, incx, &result_device, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result_device==0.0), error_name);
         //case 3: Test the n is -1
         blas::asum( -1, dx, incx, &result_device, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result_device==0.0), error_name);
         //case 4: Test the incx is 0
         blas::asum( n, dx, 0, &result_device, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result_device==0.0), error_name);
         //case 5: Test the incx is -1
         blas::asum( n, dx, -1, &result_device, queue, testcase, error_name );
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&result_device==0.0, error_name);
         queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, result_device==0.0), error_name);
+        
         params.Totalcase()+=all_testcase;
         params.Passedcase()+=passed_testcase;
         params.Failedcase()+=failed_testcase;

--- a/test/test_dot_device.cc
+++ b/test/test_dot_device.cc
@@ -125,16 +125,8 @@ void test_dot_device_work( Params& params, bool run )
         blas::dot(  n, dx,    0, dy, incy, result, queue, testcase, error_name);
         queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
-        //Test case 4: Test the return when incx is -1
-        blas::dot(  n, dx,   -1, dy, incy, result, queue, testcase, error_name);
-        queue.sync();
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
-        //Test case 5: Test the return when incy is 0
+        //Test case 4: Test the return when incy is 0
         blas::dot(  n, dx, incx, dy,    0, result, queue, testcase, error_name);
-        queue.sync();
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
-        //Test case 6: Test the return when incy is -1
-        blas::dot(  n, dx, incx, dy,   -1, result, queue, testcase, error_name);
         queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         

--- a/test/test_dot_device.cc
+++ b/test/test_dot_device.cc
@@ -115,24 +115,29 @@ void test_dot_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //Test case 1: Test the return when n is 0
         blas::dot( 0, dx, incx, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 2: Test the return when n is -1
         blas::dot( -1, dx, incx, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 3: Test the return when incx is 0
         blas::dot(  n, dx,    0, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 4: Test the return when incx is -1
         blas::dot(  n, dx,   -1, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 5: Test the return when incy is 0
         blas::dot(  n, dx, incx, dy,    0, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 6: Test the return when incy is -1
         blas::dot(  n, dx, incx, dy,   -1, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
-        
         queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+        
         params.Totalcase()+=all_testcase;
         params.Passedcase()+=passed_testcase;
         params.Failedcase()+=failed_testcase;

--- a/test/test_dotu_device.cc
+++ b/test/test_dotu_device.cc
@@ -123,16 +123,8 @@ void test_dotu_device_work( Params& params, bool run )
         blas::dotu(  n, dx,    0, dy, incy, result, queue, testcase, error_name);
         queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
-        //Test case 4: Test the return when incx is -1
-        blas::dotu(  n, dx,   -1, dy, incy, result, queue, testcase, error_name);
-        queue.sync();
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
-        //Test case 5: Test the return when incy is 0
+        //Test case 4: Test the return when incy is 0
         blas::dotu(  n, dx, incx, dy,    0, result, queue, testcase, error_name);
-        queue.sync();
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
-        //Test case 6: Test the return when incy is -1
-        blas::dotu(  n, dx, incx, dy,   -1, result, queue, testcase, error_name);
         queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         

--- a/test/test_dotu_device.cc
+++ b/test/test_dotu_device.cc
@@ -113,24 +113,29 @@ void test_dotu_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //Test case 1: Test the return when n is 0
         blas::dotu(  0, dx, incx, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 2: Test the return when n is -1
         blas::dotu( -1, dx, incx, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 3: Test the return when incx is 0
         blas::dotu(  n, dx,    0, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 4: Test the return when incx is -1
         blas::dotu(  n, dx,   -1, dy, incy, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 5: Test the return when incy is 0
         blas::dotu(  n, dx, incx, dy,    0, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 6: Test the return when incy is -1
         blas::dotu(  n, dx, incx, dy,   -1, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
-        
         queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase), error_name);
+        
         params.Totalcase()+=all_testcase;
         params.Passedcase()+=passed_testcase;
         params.Failedcase()+=failed_testcase;

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -101,21 +101,25 @@ void test_nrm2_device_work( Params& params, bool run )
         int failed_testcase = 0;
         //Test case 1: Test the return when result is an nullptr
         blas::nrm2(  n, dx, incx, nullptr, queue, testcase, error_name);
+        queue.sync();
         Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_INVALID_VALUE", all_testcase, passed_testcase, failed_testcase), error_name);
         //Test case 2: Test the return when n is 0
         blas::nrm2(  0, dx, incx, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 3: Test the return when  n is -1
         blas::nrm2( -1, dx, incx, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 4: Test the return when incx is 0
         blas::nrm2(  n, dx,    0, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
+        queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
         //Test case 5: Test the return when incx is -1
         blas::nrm2(  n, dx,   -1, result, queue, testcase, error_name);
-        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase)&&blas::isEqualToZero(result_host), error_name);
-
         queue.sync();
+        Blas_Match_Call( result_match(error_name, "CUBLAS_STATUS_SUCCESS", all_testcase, passed_testcase, failed_testcase, blas::isEqualToZero(result_host)), error_name);
+
         params.Totalcase()+=all_testcase;
         params.Passedcase()+=passed_testcase;
         params.Failedcase()+=failed_testcase;

--- a/test_scripts/correctness/test_level1_dot.sh
+++ b/test_scripts/correctness/test_level1_dot.sh
@@ -13,5 +13,5 @@ cd $TEST
 echo "-----------------------------------------Testing the illegal input of dot------------------------------------------------"
 ./$EXE --type=s,d,c,z --dim=1024 --testcase=0 dev-dot 
 echo "------------------------------------------Testing the legal input of dot-------------------------------------------------"
-./$EXE --type=s,d,c,z --dim=4,5,1024,1025,524288,524289 --incx=1,2 --incy=1,2 dev-dot 
+./$EXE --type=s,d,c,z --dim=4,5,1024,1025,524288,524289 --incx=-2,-1,1,2 --incy=-2,-1,1,2 dev-dot 
 

--- a/test_scripts/correctness/test_level1_dotu.sh
+++ b/test_scripts/correctness/test_level1_dotu.sh
@@ -13,5 +13,5 @@ cd $TEST
 echo "-----------------------------------------Testing the illegal input of dotu------------------------------------------------"
 ./$EXE --type=s,d,c,z --dim=1024 --testcase=0 dev-dotu 
 echo "------------------------------------------Testing the legal input of dotu-------------------------------------------------"
-./$EXE --type=s,d,c,z --dim=4,5,1024,1025,524288,524289 --incx=1,2 --incy=1,2 dev-dotu 
+./$EXE --type=s,d,c,z --dim=4,5,1024,1025,524288,524289 --incx=-2,-1,1,2 --incy=-2,-1,1,2 dev-dotu 
 


### PR DESCRIPTION
在dot算子非法case测试时，判断返回结果时是否为0，不应该在result_match函数外部判断，应该在函数内部进行判断，防止结果统计错误。amax、amin、asum、dot、dotu和nrm2算子同步修改。
![image](https://github.com/icode-pku/jingjia-blas-tester/assets/45275445/03dad619-6467-489f-bf58-97c9296e55e1)

在dot和dotu算子中，incx和incy可以为负数。因此，删减了非法测试case，测试脚本增加了两个规模。

